### PR TITLE
Correct Determinant(m) from -30 to 0

### DIFF
--- a/_episodes/01-command-line.md
+++ b/_episodes/01-command-line.md
@@ -224,7 +224,7 @@ Determinant(m);
 {: .source}
 
 ~~~
--30
+0
 ~~~
 {: .output}
 


### PR DESCRIPTION
One of the examples in the first session (command line) has the wrong value, -30.  It should be 0.  Thanks to an Etherpad user for pointing this out!